### PR TITLE
[TH2-1876] Fixed issue with 2 driver usage

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-release_version = 1.6.2
+release_version = 1.6.3
 description = 'remotehand'
 
 vcs_url=https://github.com/th2-net/remotehand

--- a/src/main/java/com/exactpro/remotehand/windows/WindowsDriverWrapper.java
+++ b/src/main/java/com/exactpro/remotehand/windows/WindowsDriverWrapper.java
@@ -71,7 +71,8 @@ public class WindowsDriverWrapper implements DriverCloseable
 	private WindowsDriver<?> createDriverFromHandle(String windowHandle, boolean experimental) {
 		DesiredCapabilities capabilities = this.createCommonCapabilities();
 		capabilities.setCapability(WADCapabilityType.APP_TOP_LEVEL, windowHandle);
-		return createDriver(capabilities, experimental);
+		logger.debug("Creating experimental-{} driver with handle: {}", experimental, windowHandle);
+		return createDriver(capabilities, experimental, getImplicitlyWaitTimeout(), this::setDriverExp, this::setDriverNotExp);
 	}
 
 	private WindowsDriver<?> createRootDriver(boolean experimental) {


### PR DESCRIPTION
Tool closed driver when the 2nd driver tries creating itself from 1st handleID